### PR TITLE
Give scripting access to Axis enum

### DIFF
--- a/music-theori/Scripting/ScriptProgram.cs
+++ b/music-theori/Scripting/ScriptProgram.cs
@@ -99,6 +99,7 @@ namespace theori.Scripting
 
             this["Anchor"] = typeof(Anchor);
             this["ScoreRank"] = typeof(ScoreRank);
+            this["Axis"] = typeof(Axis);
 
             static Vector2 NewVec2(float x, float y) => new Vector2(x, y);
             this["vec2"] = (Func<float, float, Vector2>)NewVec2;


### PR DESCRIPTION
This is a pretty basic type that is necessary for Neurosonic config -- currently, attempting to assign an axis in the Neurosonic control configuration results in a crash.